### PR TITLE
pc - explicitly enable annotation processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,15 @@
 
   <build>
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgument>-proc:full</compilerArgument>
+        </configuration>
+      </plugin>
+
       <!-- This fixes a problem as explained in this SO article:
       https://stackoverflow.com/a/61936537/13960329
       -->


### PR DESCRIPTION
Starting with Java 21, the following warning is produced during the compile phase unless the -proc:full is passed to the compiler:

[INFO] Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.

In this PR, we add the maven-compiler-plugin to pass this argument to the java compiler, so that this message does not appear.