### PR TITLE
pc - update version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5</version>
   </parent>
 
   <!-- (2) <groupId/> -->
@@ -51,6 +51,11 @@
     <app.package>edu.ucsb.cs156.example</app.package>
     <app.packagePath>edu/ucsb/cs156/example</app.packagePath>
     <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
+    <!-- https://mvnrepository.com/artifact/com.github.eirslett/frontend-maven-plugin -->
+    <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
+    <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-antrun-plugin -->
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <node.version>v20.17.0</node.version>
   </properties>
 
   <!-- (22) <dependencyManagement/> -->
@@ -73,16 +78,18 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-gateway-mvc-->
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-gateway-mvc</artifactId>
-      <version>4.1.3</version>
+      <version>4.1.5</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/me.paulschwarz/spring-dotenv -->
     <dependency>
       <groupId>me.paulschwarz</groupId>
       <artifactId>spring-dotenv</artifactId>
-      <version>2.4.1</version>
+      <version>4.0.0</version>
     </dependency>
 
     <dependency>
@@ -116,17 +123,20 @@
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.microsoft.playwright/playwright -->
     <dependency>
       <groupId>com.microsoft.playwright</groupId>
       <artifactId>playwright</artifactId>
-      <version>1.47.0</version>
+      <version>1.48.0</version>
       <scope>test</scope>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.wiremock/wiremock-jetty12 -->
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-jetty12</artifactId>
-      <version>3.9.1</version>
+      <version>3.9.2</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api -->
@@ -140,7 +150,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.5.0</version>
+      <version>2.6.0</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.liquibase/liquibase-maven-plugin -->
@@ -172,7 +182,7 @@
       -->
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.5.1</version>
         <configuration>
           <!-- Activate the use of TCP to transmit events to the plugin -->
           <forkNode
@@ -193,7 +203,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -399,7 +409,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.12.1</version>
+            <version>${frontend-maven-plugin.version}</version>
             <configuration>
               <workingDirectory>frontend</workingDirectory>
               <installDirectory>${project.build.directory}</installDirectory>
@@ -411,7 +421,7 @@
                   <goal>install-node-and-npm</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v20.17.0</nodeVersion>
+                  <nodeVersion>${node.version}</nodeVersion>
                 </configuration>
               </execution>
               <execution>
@@ -436,7 +446,7 @@
           </plugin>
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>${maven-antrun-plugin.version}</version>
             <executions>
               <execution>
                 <phase>generate-resources</phase>
@@ -479,7 +489,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.12.1</version>
+            <version>${frontend-maven-plugin.version}</version>
             <configuration>
               <workingDirectory>frontend</workingDirectory>
               <installDirectory>${project.build.directory}</installDirectory>
@@ -491,7 +501,7 @@
                   <goal>install-node-and-npm</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v20.17.0</nodeVersion>
+                  <nodeVersion>${node.version}</nodeVersion>
                 </configuration>
               </execution>
               <execution>
@@ -516,7 +526,7 @@
           </plugin>
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>${maven-antrun-plugin.version}</version>
             <executions>
               <execution>
                 <phase>generate-resources</phase>


### PR DESCRIPTION
In this PR, we update versions of dependencies in pom.xml to the latest version (excluding versions in alpha or beta testing).

The motivation to do this was a strange error that one student experienced that was solved by updating to the latest version of the  `maven-surefire-plugin`.

As long as we were updating, it seemed prudent to upgrade the rest of the dependencies as well.
