### PR TITLE
Ahsun w82 track unassigned issues

### DIFF
--- a/.github/workflows/82-kanban-slack-update.yml
+++ b/.github/workflows/82-kanban-slack-update.yml
@@ -217,6 +217,9 @@ jobs:
               Write-Host "Processing column: $column"
               if ($null -ne $column) {
                 $assignees = $item.content.assignees.nodes | Select-Object -ExpandProperty login
+                if ($assignees.Count -eq 0) {
+                  $assignees = @("UNASSIGNED")
+                }
                 foreach ($assignee in $assignees) {
                   Write-Host "Processing assignee: $assignee"
                   if (-not $issueCounts.ContainsKey($column)) {
@@ -282,14 +285,20 @@ jobs:
           }
           $issueCounts = $issueCounts | ConvertFrom-Json
 
-          # Collect all assignees
-          $assignees = @{ }
+          # Collect all assignees and track unassigned issues
+          $assignees = @{}
+          $unassignedCounts = @{}
           foreach ($column in $issueCounts.PSObject.Properties.Name) {
+            $unassignedCounts[$column] = 0
             foreach ($assignee in $issueCounts.$column.PSObject.Properties.Name) {
-              if (-not $assignees.ContainsKey($assignee)) {
-                $assignees[$assignee] = @{ }
+              if ($assignee -eq "UNASSIGNED") {
+                $unassignedCounts[$column] += $issueCounts.$column.$assignee
+              } else {
+                if (-not $assignees.ContainsKey($assignee)) {
+                  $assignees[$assignee] = @{}
+                }
+                $assignees[$assignee][$column] = $issueCounts.$column.$assignee
               }
-              $assignees[$assignee][$column] = $issueCounts.$column.$assignee
             }
           }
 
@@ -297,7 +306,7 @@ jobs:
           $columns = $env:columns -split ", "
           $columnWidths = @(18, 3, 3, 3, 3)  # Fixed widths for each column
 
-          # Left align the text within each cell with manual adjustments
+          # Left align the text within each cell
           function LeftAlignText($text, $width) {
             $text = [string]$text  # Ensure $text is treated as a string
             $padding = " " * [math]::Max(0, $width - $text.Length)
@@ -309,6 +318,7 @@ jobs:
           foreach ($column in $columns) {
             $header += " " + $column.Substring(0, 4) + " |"
           }
+
 
           # Define the separator with exact dash counts for each column
           $separator = "|------------------|"
@@ -329,6 +339,15 @@ jobs:
             }
             $table += "$row`n"
           }
+
+          # Add the unassigned row
+          $unassignedRow = "| " + (LeftAlignText "UNASSIGNED" 17) + "|"
+          foreach ($column in $columns) {
+            $unassignedCount = $unassignedCounts[$column]
+            $leftAlignedUnassignedCount = printf "%-4s" $unassignedCount
+            $unassignedRow += " $leftAlignedUnassignedCount |"
+          }
+          $table += "$unassignedRow`n"
 
           Write-Host "ASCII Table:`n$table"
           $table | Out-File ascii_table.txt

--- a/.github/workflows/82-kanban-slack-update.yml
+++ b/.github/workflows/82-kanban-slack-update.yml
@@ -348,7 +348,7 @@ jobs:
           $unassignedRow = "| " + (LeftAlignText "UNASSIGNED" 17) + "|"
           foreach ($column in $columns) {
             $unassignedCount = $unassignedCounts[$column]
-            $leftAlignedUnassignedCount = printf "%-4s" $unassignedCount
+            $leftAlignedUnassignedCount = printf "%4s" $unassignedCount
             $unassignedRow += " $leftAlignedUnassignedCount |"
           }
           $table += "$unassignedRow`n"


### PR DESCRIPTION
This PR adds a row tracking unassigned issues under the kanban board table in workflow #82.

![image](https://github.com/user-attachments/assets/bfe0b4a6-0ef8-4987-8081-d035c41be44c)

We do this by checking if the issue item has zero assignee in the count issues job:
   ```
             if ($assignees.Count -eq 0) {
                  $assignees = @("UNASSIGNED")
                }
```
Finally in the generate ascii table job, we add the row for unassigned issues:

```
          $unassignedRow = "| " + (LeftAlignText "UNASSIGNED" 17) + "|"
          foreach ($column in $columns) {
            $unassignedCount = $unassignedCounts[$column]
            $leftAlignedUnassignedCount = printf "%-4s" $unassignedCount
            $unassignedRow += " $leftAlignedUnassignedCount |"
          }
          $table += "$unassignedRow`n"

```